### PR TITLE
Slider timestamp

### DIFF
--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -24,7 +24,7 @@ from django.core.urlresolvers import reverse
 from omeroweb.decorators import login_required
 from omeroweb.webgateway.marshal import imageMarshal
 from omeroweb.webgateway.templatetags.common_filters import lengthformat,\
-    lengthunit, timeformat
+    lengthunit
 
 import json
 import omero_marshal
@@ -265,7 +265,7 @@ def image_data(request, image_id, conn=None, **kwargs):
             t_index = info.theT.getValue()
             if info.deltaT is not None:
                 value = format_value_with_units(info.deltaT)
-                timemap[t_index] = value[0]
+                timemap[t_index] = round(value[0])
                 if delta_t_unit_symbol is None:
                     delta_t_unit_symbol = value[1]
         for t in range(image.getSizeT()):
@@ -292,14 +292,15 @@ def format_value_with_units(value):
         if unit == "MICROMETER":
             unit = lengthunit(length)
             length = lengthformat(length)
-        elif unit == "s":
-            length = timeformat(length)
-        elif unit == "ms":
-            length = timeformat(length/1000.0)
-        elif unit == "min":
-            length = timeformat(60*length)
-        elif unit == "h":
-            length = timeformat(3600*length)
+        elif unit == "MILLISECOND":
+            length = length/1000.0
+            unit = value.getSymbol()
+        elif unit == "MINUTE":
+            length = 60*length
+            unit = value.getSymbol()
+        elif unit == "HOUR":
+            length = 3600*length
+            unit = value.getSymbol()
         else:
             unit = value.getSymbol()
         return (length, unit)

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -263,7 +263,6 @@ def image_data(request, image_id, conn=None, **kwargs):
         info_list = conn.getQueryService().findAllByQuery(
             query, params, conn.SERVICE_OPTS)
         timemap = {}
-        exposuremap = {}
         for info in info_list:
             t_index = info.theT.getValue()
             if info.deltaT is not None:
@@ -271,19 +270,12 @@ def image_data(request, image_id, conn=None, **kwargs):
                 timemap[t_index] = value[0]
                 if delta_t_unit_symbol is None:
                     delta_t_unit_symbol = value[1]
-                v = format_value_with_units(info.exposureTime)
-                exposuremap[t_index] = v[0]
-                if exposure_unit_symbol is None:
-                    exposure_unit_symbol = v[1]
         for t in range(image.getSizeT()):
             if t in timemap:
                 time_list.append(timemap[t])
-                exposure_list.append(exposuremap[t])
 
     rv['delta_t'] = time_list
     rv['delta_t_unit_symbol'] = delta_t_unit_symbol
-    rv['exposure_time'] = exposure_list
-    rv['exposure_time_unit_symbol'] = exposure_unit_symbol
 
     return JsonResponse(rv)
 
@@ -299,7 +291,7 @@ def format_value_with_units(value):
             return (None, "")
         length = value.getValue()
         unit = value.getUnit()
-        if unit == "MICROMETER" or unit == "s":
+        if unit == "MICROMETER":
             unit = lengthunit(length)
             length = lengthformat(length)
         else:

--- a/plugin/omero_iviewer/views.py
+++ b/plugin/omero_iviewer/views.py
@@ -24,7 +24,7 @@ from django.core.urlresolvers import reverse
 from omeroweb.decorators import login_required
 from omeroweb.webgateway.marshal import imageMarshal
 from omeroweb.webgateway.templatetags.common_filters import lengthformat,\
-    lengthunit
+    lengthunit, timeformat
 
 import json
 import omero_marshal
@@ -251,8 +251,6 @@ def image_data(request, image_id, conn=None, **kwargs):
     size_t = image.getSizeT()
     time_list = []
     delta_t_unit_symbol = None
-    exposure_list = []
-    exposure_unit_symbol = None
     if size_t > 1:
         params = omero.sys.ParametersI()
         params.addLong('pid', image.getPixelsId())
@@ -294,6 +292,14 @@ def format_value_with_units(value):
         if unit == "MICROMETER":
             unit = lengthunit(length)
             length = lengthformat(length)
+        elif unit == "s":
+            length = timeformat(length)
+        elif unit == "ms":
+            length = timeformat(length/1000.0)
+        elif unit == "min":
+            length = timeformat(60*length)
+        elif unit == "h":
+            length = timeformat(3600*length)
         else:
             unit = value.getSymbol()
         return (length, unit)

--- a/src/controls/dimension-slider.html
+++ b/src/controls/dimension-slider.html
@@ -37,11 +37,11 @@
         <span class='dim-size'>
             ${image_config.image_info.dimensions['max_' + dim]}
         </span>
-        <span show.bind="image_config.image_info.image_exposure.length > 0"
+        <span show.bind="image_config.image_info.image_delta_t.length > 0"
               class="timestamp">
             ${image_config.image_info.dimensions[dim] &lt;
-                image_config.image_info.image_exposure.length ?
-                    image_config.image_info.image_exposure[
+                image_config.image_info.image_delta_t.length ?
+                    image_config.image_info.image_delta_t[
                         image_config.image_info.dimensions[dim]] : '&nbsp;'}
         </span>
     </template>

--- a/src/model/image_info.js
+++ b/src/model/image_info.js
@@ -107,20 +107,6 @@ export default class ImageInfo {
     image_delta_t_unit = "s";
 
     /**
-     * the exposure time
-     * @type {Array.<number>}
-     * @memberof ImageInfo
-     */
-    image_exposure_time = [];
-
-    /**
-     * the exposure time unit. default is seconds 
-     * @type {string}
-     * @memberof ImageInfo
-     */
-    image_exposure_time_unit = "s";
-
-    /**
      * a flag for whether we are allowed to save the settings
      * @memberof ImageInfo
      * @type {boolean}
@@ -335,8 +321,6 @@ export default class ImageInfo {
         this.image_pixels_size = response.pixel_size;
         this.image_delta_t = response.delta_t;
         this.image_delta_t_unit = response.delta_t_unit_symbol;
-        this.image_exposure_time = response.exposure_time;
-        this.image_exposure_time_unit = response.exposure_time_unit_symbol;
         this.sanityCheckInitialValues();
         // signal that we are ready and
         // send out an image config update event


### PR DESCRIPTION
Remove the exposure time
Convert the value it seconds but still return the symbol stored in DB (in case it is useful)
We can remove it